### PR TITLE
Fix ci.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4273,9 +4273,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -9113,9 +9113,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/sites-config/ci.json
+++ b/sites-config/ci.json
@@ -17,7 +17,7 @@
           },
           {
             "root": "dist",
-            "pattern": "assets/{server,static}/**"
+            "pattern": "assets/{server,static}/**/*{.js,.css}"
           }
         ],
         "event": "ON_PAGE_GENERATE",


### PR DESCRIPTION
Had to update the ci config to only include files with js and css
extensions with the plugin. The files were all being copied
correctly, but the generated pluginFileMap.json was including
the directory node as a source file which was causing an
error. This makes sure that the correct files are still copied
over and that the directory node is not listed as a source file
in the pluginFileMap.

J=none
TEST=manual

Manually tested locally. Will need to deploy to fully test.