### PR TITLE
Fix react import

### DIFF
--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,4 +1,4 @@
-import * as React from "React";
+import * as React from "react";
 
 type CardProps = {
   title: string;


### PR DESCRIPTION
This is causing issues on case-sensitive filesystems such as Yext CI as "React" is not a valid module name -- only "react".