### PR TITLE
Path in Starter Repo is Broken

### DIFF
--- a/src/templates/location.tsx
+++ b/src/templates/location.tsx
@@ -71,7 +71,7 @@ export const getPath: GetPath<TemplateProps> = ({ document }) => {
   return document.slug
     ? document.slug
     : `${document.locale}/${document.address.region}/${document.address.city}/${
-        document.address.address1
+        document.address.line1
       }-${document.id.toString()}`;
 };
 


### PR DESCRIPTION
The field is named `line1` not `address1`