### PR TITLE
Update PagesJS version to include Multi-brand.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
         "@vitejs/plugin-react": "^2.1.0",
-        "@yext/pages": "1.0.0-beta.6",
+        "@yext/pages": "1.0.0-beta.10",
         "autoprefixer": "^10.4.8",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.31.7",
@@ -32,163 +32,6 @@
       },
       "engines": {
         "node": ">=17"
-      }
-    },
-    "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
-      }
-    },
-    "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
-      },
-      "peerDependencies": {
-        "@algolia/client-search": "^4.9.1",
-        "algoliasearch": "^4.9.1"
-      }
-    },
-    "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg==",
-      "dev": true
-    },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg==",
-      "dev": true
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA==",
-      "dev": true
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/logger-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg==",
-      "dev": true
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.14.2"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -624,50 +467,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g==",
-      "dev": true
-    },
-    "node_modules/@docsearch/js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.2.1.tgz",
-      "integrity": "sha512-H1PekEtSeS0msetR2YGGey2w7jQ2wAKfGODJvQTygSwMgUZ+2DHpzUgeDyEBIXRIfaBcoQneqrzsljM62pm6Xg==",
-      "dev": true,
-      "dependencies": {
-        "@docsearch/react": "3.2.1",
-        "preact": "^10.0.0"
-      }
-    },
-    "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
-        "algoliasearch": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 19.0.0",
-        "react": ">= 16.8.0 < 19.0.0",
-        "react-dom": ">= 16.8.0 < 19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
@@ -904,12 +703,6 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
-    "node_modules/@types/web-bluetooth": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.14.tgz",
-      "integrity": "sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A==",
-      "dev": true
-    },
     "node_modules/@types/yoga-layout": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
@@ -1122,218 +915,40 @@
         "vite": "^3.0.0"
       }
     },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.33.tgz",
-      "integrity": "sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.33.tgz",
-      "integrity": "sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.33.tgz",
-      "integrity": "sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/reactivity-transform": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.33.tgz",
-      "integrity": "sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "node_modules/@vue/reactivity": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.33.tgz",
-      "integrity": "sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.33.tgz",
-      "integrity": "sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "node_modules/@vue/reactivity-transform/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.33.tgz",
-      "integrity": "sha512-N2D2vfaXsBPhzCV3JsXQa2NECjxP3eXgZlFqKh4tgakp3iX6LCGv76DLlc+IfFZq+TW10Y8QUfeihXOupJ1dGw==",
-      "dev": true,
-      "dependencies": {
-        "@vue/reactivity": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.33.tgz",
-      "integrity": "sha512-LSrJ6W7CZTSUygX5s8aFkraDWlO6K4geOwA3quFF2O+hC3QuAMZt/0Xb7JKE3C4JD4pFwCSO7oCrZmZ0BIJUnw==",
-      "dev": true,
-      "dependencies": {
-        "@vue/runtime-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "csstype": "^2.6.8"
-      }
-    },
-    "node_modules/@vue/runtime-dom/node_modules/csstype": {
-      "version": "2.6.20",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
-      "dev": true
-    },
-    "node_modules/@vue/server-renderer": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.33.tgz",
-      "integrity": "sha512-4jpJHRD4ORv8PlbYi+/MfP8ec1okz6rybe36MdpkDrGIdEItHEUyaHSKvz+ptNEyQpALmmVfRteHkU9F8vxOew==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/shared": "3.2.33"
-      },
-      "peerDependencies": {
-        "vue": "3.2.33"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.33.tgz",
-      "integrity": "sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==",
-      "dev": true
-    },
-    "node_modules/@vueuse/core": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.4.tgz",
-      "integrity": "sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/web-bluetooth": "^0.0.14",
-        "@vueuse/metadata": "8.9.4",
-        "@vueuse/shared": "8.9.4",
-        "vue-demi": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.0",
-        "vue": "^2.6.0 || ^3.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vueuse/metadata": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.4.tgz",
-      "integrity": "sha512-IwSfzH80bnJMzqhaapqJl9JRIiyQU0zsRGEgnxN6jhq7992cPUJIRfV+JHRIZXjYqbwt07E1gTEp0R0zPJ1aqw==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.4.tgz",
-      "integrity": "sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==",
-      "dev": true,
-      "dependencies": {
-        "vue-demi": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.1.0",
-        "vue": "^2.6.0 || ^3.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@yext/analytics": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.2.0.tgz",
-      "integrity": "sha512-0DoYb9IqxbnIEjwddULDMlXgaPxjwB56xhFH+1QR52Xc5p11iotgcZK/wpXXZAI29ilXhQTLEDc8qGZEfHPC2Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.3.0.tgz",
+      "integrity": "sha512-b2sXkoEmCdQyO2nbuYATOOQ1gs501bOUd1GxE8u7dQmhcYCyzzbUKQ07hzWRJoP6I3/Rf1o0fEfXsnlb5vmcnA==",
       "dev": true,
       "dependencies": {
         "cross-fetch": "^3.1.5"
       }
     },
-    "node_modules/@yext/pages": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@yext/pages/-/pages-1.0.0-beta.6.tgz",
-      "integrity": "sha512-ACLSSnsBEtt573YXJVznAD60d7rc2KIFMbRfV8NaVwkVz1bVpgXODl0UUK+hSp/zVg9SC/IEEKeib1ONwrVV3Q==",
+    "node_modules/@yext/components-tsx-geo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@yext/components-tsx-geo/-/components-tsx-geo-1.0.3.tgz",
+      "integrity": "sha512-dcxvyEBo4b0yKuiummdDh6J+FP6lXK2wsBYyNxBGeLXYrjUZYXarQn6knHyRNClVHNEZ0jjKKW7QN7JwFd+LlQ==",
+      "dev": true
+    },
+    "node_modules/@yext/components-tsx-maps": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@yext/components-tsx-maps/-/components-tsx-maps-1.0.9.tgz",
+      "integrity": "sha512-VlI93irRqIyd3YLrOtogL4LfnB11QotMjRqUzOWytBth34EV0AAuCAHxFBM5CtNM7/GwudkQvK4Hx0UgMkGQqA==",
       "dev": true,
       "dependencies": {
-        "@yext/analytics": "^0.2.0",
+        "@yext/components-tsx-geo": "^1.0.3",
+        "typescript": "^4.7.3"
+      }
+    },
+    "node_modules/@yext/pages": {
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@yext/pages/-/pages-1.0.0-beta.10.tgz",
+      "integrity": "sha512-QdDKkgSX+Rmo4nx/vrvohQBLqCE1IYNx5pQ7s6hQJLX0dXXWW/c6FG+Z88dFyK5scUpNNifSgLsHNUS1fnVFaA==",
+      "dev": true,
+      "dependencies": {
+        "@yext/analytics": "^0.3.0",
+        "@yext/components-tsx-geo": "^1.0.3",
+        "@yext/components-tsx-maps": "^1.0.9",
         "ansi-to-html": "^0.7.2",
         "chalk": "^5.0.1",
         "classnames": "2.3.1",
@@ -1348,6 +963,7 @@
         "handlebars": "^4.7.7",
         "ink": "^3.2.0",
         "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
         "module-from-string": "^3.2.1",
         "open": "^8.4.0",
         "ora": "^6.1.2",
@@ -1357,7 +973,7 @@
         "shelljs": "^0.8.5",
         "typescript": "^4.8.2",
         "vite": "^3.1.0",
-        "vitepress": "1.0.0-draft.8"
+        "yargs": "^17.6.0"
       },
       "bin": {
         "pages": "dist/bin/pages.sh"
@@ -1471,28 +1087,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
       }
     },
     "node_modules/ansi-colors": {
@@ -1799,12 +1393,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/body-scroll-lock": {
-      "version": "4.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz",
-      "integrity": "sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==",
-      "dev": true
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2068,6 +1656,70 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -3262,12 +2914,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3849,6 +3495,15 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4745,12 +4400,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -5818,16 +5467,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/preact": {
-      "version": "10.10.6",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.10.6.tgz",
-      "integrity": "sha512-w0mCL5vICUAZrh1DuHEdOWBjxdO62lvcO++jbzr8UhhYcTbFkpegLH9XX+7MadjTl/y0feoqwQ/zAnzkc/EGog==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6183,6 +5822,15 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
@@ -6454,17 +6102,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
-      "dev": true,
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/side-channel": {
@@ -7588,161 +7225,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/vitepress": {
-      "version": "1.0.0-draft.8",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-draft.8.tgz",
-      "integrity": "sha512-r1cphHgtJ/KFwtph3cyusGWjRyX0NHvwfBboKnG5mRJpOP/JyvX5q5+NIiRYElPgdFXU7Roxkl8BcJbxWht56Q==",
-      "dev": true,
-      "dependencies": {
-        "@docsearch/css": "^3.0.0",
-        "@docsearch/js": "^3.0.0",
-        "@vitejs/plugin-vue": "^2.3.2",
-        "@vueuse/core": "^8.5.0",
-        "body-scroll-lock": "^4.0.0-beta.0",
-        "shiki": "^0.10.1",
-        "vite": "^2.9.7",
-        "vue": "3.2.33"
-      },
-      "bin": {
-        "vitepress": "bin/vitepress.js"
-      },
-      "engines": {
-        "node": ">=14.6.0"
-      }
-    },
-    "node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.4.tgz",
-      "integrity": "sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^2.5.10",
-        "vue": "^3.2.25"
-      }
-    },
-    "node_modules/vitepress/node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/vitepress/node_modules/rollup": {
-      "version": "2.77.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/vitepress/node_modules/vite": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
-      "dev": true,
-      "dependencies": {
-        "esbuild": "^0.14.27",
-        "postcss": "^8.4.13",
-        "resolve": "^1.22.0",
-        "rollup": ">=2.59.0 <2.78.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": ">=12.2.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "less": "*",
-        "sass": "*",
-        "stylus": "*"
-      },
-      "peerDependenciesMeta": {
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
-      "dev": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
-      "dev": true
-    },
-    "node_modules/vue": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.33.tgz",
-      "integrity": "sha512-si1ExAlDUrLSIg/V7D/GgA4twJwfsfgG+t9w10z38HhL/HA07132pUQ2KuwAo8qbCyMJ9e6OqrmWrOCr+jW7ZQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-sfc": "3.2.33",
-        "@vue/runtime-dom": "3.2.33",
-        "@vue/server-renderer": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "node_modules/vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -7911,6 +7393,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -7924,6 +7415,33 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {
@@ -7953,159 +7471,6 @@
     }
   },
   "dependencies": {
-    "@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
-      "dev": true,
-      "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
-      }
-    },
-    "@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
-      "dev": true,
-      "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
-      }
-    },
-    "@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg==",
-      "dev": true
-    },
-    "@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.14.2"
-      }
-    },
-    "@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg==",
-      "dev": true
-    },
-    "@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.14.2"
-      }
-    },
-    "@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
-      }
-    },
-    "@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA==",
-      "dev": true
-    },
-    "@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
-      "dev": true,
-      "requires": {
-        "@algolia/logger-common": "4.14.2"
-      }
-    },
-    "@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.14.2"
-      }
-    },
-    "@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg==",
-      "dev": true
-    },
-    "@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.14.2"
-      }
-    },
-    "@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -8424,34 +7789,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g==",
-      "dev": true
-    },
-    "@docsearch/js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.2.1.tgz",
-      "integrity": "sha512-H1PekEtSeS0msetR2YGGey2w7jQ2wAKfGODJvQTygSwMgUZ+2DHpzUgeDyEBIXRIfaBcoQneqrzsljM62pm6Xg==",
-      "dev": true,
-      "requires": {
-        "@docsearch/react": "3.2.1",
-        "preact": "^10.0.0"
-      }
-    },
-    "@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
-        "algoliasearch": "^4.0.0"
-      }
-    },
     "@esbuild/linux-loong64": {
       "version": "0.14.54",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
@@ -8631,12 +7968,6 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
-    "@types/web-bluetooth": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.14.tgz",
-      "integrity": "sha512-5d2RhCard1nQUC3aHcq/gHzWYO6K0WJmAbjO7mQJgCQKtZpgXxv1rOM6O/dBDhDYYVutk1sciOgNSe+5YyfM8A==",
-      "dev": true
-    },
     "@types/yoga-layout": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
@@ -8754,188 +8085,40 @@
         "react-refresh": "^0.14.0"
       }
     },
-    "@vue/compiler-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.33.tgz",
-      "integrity": "sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "@vue/compiler-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.33.tgz",
-      "integrity": "sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/compiler-sfc": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.33.tgz",
-      "integrity": "sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/reactivity-transform": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.25.9",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.8"
-          }
-        }
-      }
-    },
-    "@vue/compiler-ssr": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.33.tgz",
-      "integrity": "sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/reactivity": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.33.tgz",
-      "integrity": "sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==",
-      "dev": true,
-      "requires": {
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/reactivity-transform": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.33.tgz",
-      "integrity": "sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.25.9",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.8"
-          }
-        }
-      }
-    },
-    "@vue/runtime-core": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.33.tgz",
-      "integrity": "sha512-N2D2vfaXsBPhzCV3JsXQa2NECjxP3eXgZlFqKh4tgakp3iX6LCGv76DLlc+IfFZq+TW10Y8QUfeihXOupJ1dGw==",
-      "dev": true,
-      "requires": {
-        "@vue/reactivity": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/runtime-dom": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.33.tgz",
-      "integrity": "sha512-LSrJ6W7CZTSUygX5s8aFkraDWlO6K4geOwA3quFF2O+hC3QuAMZt/0Xb7JKE3C4JD4pFwCSO7oCrZmZ0BIJUnw==",
-      "dev": true,
-      "requires": {
-        "@vue/runtime-core": "3.2.33",
-        "@vue/shared": "3.2.33",
-        "csstype": "^2.6.8"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "2.6.20",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
-          "dev": true
-        }
-      }
-    },
-    "@vue/server-renderer": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.33.tgz",
-      "integrity": "sha512-4jpJHRD4ORv8PlbYi+/MfP8ec1okz6rybe36MdpkDrGIdEItHEUyaHSKvz+ptNEyQpALmmVfRteHkU9F8vxOew==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-ssr": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "@vue/shared": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.33.tgz",
-      "integrity": "sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==",
-      "dev": true
-    },
-    "@vueuse/core": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.9.4.tgz",
-      "integrity": "sha512-B/Mdj9TK1peFyWaPof+Zf/mP9XuGAngaJZBwPaXBvU3aCTZlx3ltlrFFFyMV4iGBwsjSCeUCgZrtkEj9dS2Y3Q==",
-      "dev": true,
-      "requires": {
-        "@types/web-bluetooth": "^0.0.14",
-        "@vueuse/metadata": "8.9.4",
-        "@vueuse/shared": "8.9.4",
-        "vue-demi": "*"
-      }
-    },
-    "@vueuse/metadata": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.9.4.tgz",
-      "integrity": "sha512-IwSfzH80bnJMzqhaapqJl9JRIiyQU0zsRGEgnxN6jhq7992cPUJIRfV+JHRIZXjYqbwt07E1gTEp0R0zPJ1aqw==",
-      "dev": true
-    },
-    "@vueuse/shared": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.9.4.tgz",
-      "integrity": "sha512-wt+T30c4K6dGRMVqPddexEVLa28YwxW5OFIPmzUHICjphfAuBFTTdDoyqREZNDOFJZ44ARH1WWQNCUK8koJ+Ag==",
-      "dev": true,
-      "requires": {
-        "vue-demi": "*"
-      }
-    },
     "@yext/analytics": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.2.0.tgz",
-      "integrity": "sha512-0DoYb9IqxbnIEjwddULDMlXgaPxjwB56xhFH+1QR52Xc5p11iotgcZK/wpXXZAI29ilXhQTLEDc8qGZEfHPC2Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.3.0.tgz",
+      "integrity": "sha512-b2sXkoEmCdQyO2nbuYATOOQ1gs501bOUd1GxE8u7dQmhcYCyzzbUKQ07hzWRJoP6I3/Rf1o0fEfXsnlb5vmcnA==",
       "dev": true,
       "requires": {
         "cross-fetch": "^3.1.5"
       }
     },
-    "@yext/pages": {
-      "version": "1.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@yext/pages/-/pages-1.0.0-beta.6.tgz",
-      "integrity": "sha512-ACLSSnsBEtt573YXJVznAD60d7rc2KIFMbRfV8NaVwkVz1bVpgXODl0UUK+hSp/zVg9SC/IEEKeib1ONwrVV3Q==",
+    "@yext/components-tsx-geo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@yext/components-tsx-geo/-/components-tsx-geo-1.0.3.tgz",
+      "integrity": "sha512-dcxvyEBo4b0yKuiummdDh6J+FP6lXK2wsBYyNxBGeLXYrjUZYXarQn6knHyRNClVHNEZ0jjKKW7QN7JwFd+LlQ==",
+      "dev": true
+    },
+    "@yext/components-tsx-maps": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@yext/components-tsx-maps/-/components-tsx-maps-1.0.9.tgz",
+      "integrity": "sha512-VlI93irRqIyd3YLrOtogL4LfnB11QotMjRqUzOWytBth34EV0AAuCAHxFBM5CtNM7/GwudkQvK4Hx0UgMkGQqA==",
       "dev": true,
       "requires": {
-        "@yext/analytics": "^0.2.0",
+        "@yext/components-tsx-geo": "^1.0.3",
+        "typescript": "^4.7.3"
+      }
+    },
+    "@yext/pages": {
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@yext/pages/-/pages-1.0.0-beta.10.tgz",
+      "integrity": "sha512-QdDKkgSX+Rmo4nx/vrvohQBLqCE1IYNx5pQ7s6hQJLX0dXXWW/c6FG+Z88dFyK5scUpNNifSgLsHNUS1fnVFaA==",
+      "dev": true,
+      "requires": {
+        "@yext/analytics": "^0.3.0",
+        "@yext/components-tsx-geo": "^1.0.3",
+        "@yext/components-tsx-maps": "^1.0.9",
         "ansi-to-html": "^0.7.2",
         "chalk": "^5.0.1",
         "classnames": "2.3.1",
@@ -8950,6 +8133,7 @@
         "handlebars": "^4.7.7",
         "ink": "^3.2.0",
         "lodash": "^4.17.21",
+        "mime-types": "^2.1.35",
         "module-from-string": "^3.2.1",
         "open": "^8.4.0",
         "ora": "^6.1.2",
@@ -8959,7 +8143,7 @@
         "shelljs": "^0.8.5",
         "typescript": "^4.8.2",
         "vite": "^3.1.0",
-        "vitepress": "1.0.0-draft.8"
+        "yargs": "^17.6.0"
       },
       "dependencies": {
         "chalk": {
@@ -9037,28 +8221,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      }
-    },
-    "algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
       }
     },
     "ansi-colors": {
@@ -9272,12 +8434,6 @@
         }
       }
     },
-    "body-scroll-lock": {
-      "version": "4.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz",
-      "integrity": "sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==",
-      "dev": true
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -9445,6 +8601,54 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
     },
     "clone": {
       "version": "1.0.4",
@@ -10244,12 +9448,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10705,6 +9903,12 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-intrinsic": {
@@ -11327,12 +10531,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true
-    },
-    "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "jsonfile": {
@@ -12084,12 +11282,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "preact": {
-      "version": "10.10.6",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.10.6.tgz",
-      "integrity": "sha512-w0mCL5vICUAZrh1DuHEdOWBjxdO62lvcO++jbzr8UhhYcTbFkpegLH9XX+7MadjTl/y0feoqwQ/zAnzkc/EGog==",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12346,6 +11538,12 @@
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
     "resolve": {
       "version": "2.0.0-next.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
@@ -12549,17 +11747,6 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
-      }
-    },
-    "shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
-      "dev": true,
-      "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
       }
     },
     "side-channel": {
@@ -13284,96 +12471,6 @@
         }
       }
     },
-    "vitepress": {
-      "version": "1.0.0-draft.8",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-draft.8.tgz",
-      "integrity": "sha512-r1cphHgtJ/KFwtph3cyusGWjRyX0NHvwfBboKnG5mRJpOP/JyvX5q5+NIiRYElPgdFXU7Roxkl8BcJbxWht56Q==",
-      "dev": true,
-      "requires": {
-        "@docsearch/css": "^3.0.0",
-        "@docsearch/js": "^3.0.0",
-        "@vitejs/plugin-vue": "^2.3.2",
-        "@vueuse/core": "^8.5.0",
-        "body-scroll-lock": "^4.0.0-beta.0",
-        "shiki": "^0.10.1",
-        "vite": "^2.9.7",
-        "vue": "3.2.33"
-      },
-      "dependencies": {
-        "@vitejs/plugin-vue": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.4.tgz",
-          "integrity": "sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==",
-          "dev": true,
-          "requires": {}
-        },
-        "resolve": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-          "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.9.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
-          }
-        },
-        "rollup": {
-          "version": "2.77.3",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-          "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
-          "dev": true,
-          "requires": {
-            "fsevents": "~2.3.2"
-          }
-        },
-        "vite": {
-          "version": "2.9.15",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-          "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
-          "dev": true,
-          "requires": {
-            "esbuild": "^0.14.27",
-            "fsevents": "~2.3.2",
-            "postcss": "^8.4.13",
-            "resolve": "^1.22.0",
-            "rollup": ">=2.59.0 <2.78.0"
-          }
-        }
-      }
-    },
-    "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
-      "dev": true
-    },
-    "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
-      "dev": true
-    },
-    "vue": {
-      "version": "3.2.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.33.tgz",
-      "integrity": "sha512-si1ExAlDUrLSIg/V7D/GgA4twJwfsfgG+t9w10z38HhL/HA07132pUQ2KuwAo8qbCyMJ9e6OqrmWrOCr+jW7ZQ==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-dom": "3.2.33",
-        "@vue/compiler-sfc": "3.2.33",
-        "@vue/runtime-dom": "3.2.33",
-        "@vue/server-renderer": "3.2.33",
-        "@vue/shared": "3.2.33"
-      }
-    },
-    "vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-      "dev": true,
-      "requires": {}
-    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -13500,6 +12597,12 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -13510,6 +12613,27 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "@vitejs/plugin-react": "^2.1.0",
-    "@yext/pages": "1.0.0-beta.6",
+    "@yext/pages": "1.0.0-beta.10",
     "autoprefixer": "^10.4.8",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.31.7",


### PR DESCRIPTION
This PR updates the PagesJS version to 1.0.0-beta.10. This version includes Multi-brand, but not the Local Dev URLs feature. The latter will be made publicly available in January.