### PR TITLE
disable .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# Environment variables must be prefixed with YEXT_PUBLIC to work for the
-# time being and can be accessed in templates via 'import.meta.env.[name]'. 
-# We are using Vite's built in handling of environemnt variables, so various 
-# .env files can be configured, such as .env.local or .env.production. See 
-# here for mode details: https://vitejs.dev/guide/env-and-mode.html#env-files
-
-YEXT_PUBLIC_EXTERNAL_IMAGE_API_BASE_URL=https://jsonplaceholder.typicode.com/photos

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Environment variables must be prefixed with YEXT_PUBLIC, and can be accessed
+# in templates directly without a reference. We are using Vite's built in
+# handling of environment variables, so various .env files can be configured,
+# such as .env.local or .env.production. See here for mode details:
+# https://vitejs.dev/guide/env-and-mode.html#env-files
+
+YEXT_PUBLIC_EXTERNAL_IMAGE_API_BASE_URL=https://jsonplaceholder.typicode.com/photos

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ dist/
 .artifact-output
 sites-config/features.json
 *.local
+.env
 
 .DS_Store

--- a/src/templates/static.tsx
+++ b/src/templates/static.tsx
@@ -47,7 +47,7 @@ type ExternalImageData = TemplateProps & { externalImage: ExternalImage };
 export const transformProps: TransformProps<ExternalImageData> = async (
   data
 ) => {
-  const url = import.meta.env.YEXT_PUBLIC_EXTERNAL_IMAGE_API_BASE_URL + "/2";
+  const url = "https://jsonplaceholder.typicode.com/photos/2";
   const externalImage = (await fetch(url).then((res: any) =>
     res.json()
   )) as ExternalImage;


### PR DESCRIPTION
replace .env with example usage so that users don't start with environment variables checked in thinking that is intentional

J=SLAP-2506
TEST=manual

see .env removed from git